### PR TITLE
RockYou Adapter: Ad Size / Multiple Ad Unit update

### DIFF
--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -6,7 +6,7 @@ import { registerBidder } from 'src/adapters/bidderFactory';
 const BIDDER_CODE = 'rockyou';
 
 const BASE_REQUEST_PATH = 'https://tas.rockyou.net/servlet/rotator/';
-const IFRAME_SYNC_URL = 'https://prebid.tex-sync.rockyou.net/usersync2/tas';
+const IFRAME_SYNC_URL = 'https://prebid.tas-sync.rockyou.net/usersync2/prebid';
 const VAST_PLAYER_LOCATION = 'https://rya-static.rockyou.com/rya/js/PreBidPlayer.js';
 export const ROTATION_ZONE = 'prod';
 

--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -194,6 +194,7 @@ let buildRequests = (validBidRequests, requestRoot) => {
           data: requestPayload,
           mediaTypes,
           requestId: requestRoot.bidderRequestId,
+          bidId: bidRequest.bidId,
           adUnitCode,
           rendererOverride
         };
@@ -314,7 +315,7 @@ let interpretResponse = (serverResponse, request) => {
         }
 
         let response = {
-          requestId: responseBody.id,
+          requestId: request.bidId,
           cpm: bid.price,
           width: bidWidth,
           height: bidHeight,

--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -8,7 +8,7 @@ const BIDDER_CODE = 'rockyou';
 const BASE_REQUEST_PATH = 'https://tas.rockyou.net/servlet/rotator/';
 const IFRAME_SYNC_URL = 'https://prebid.tex-sync.rockyou.net/usersync2/tas';
 const VAST_PLAYER_LOCATION = 'https://rya-static.rockyou.com/rya/js/PreBidPlayer.js';
-export const ROTATION_ZONE = 'openrtbprod';
+export const ROTATION_ZONE = 'prod';
 
 let isBidRequestValid = (bid) => {
   return !!bid.params && !!bid.params.placementId;
@@ -52,17 +52,27 @@ let extractValidSize = (bidRequest) => {
   let width = null;
   let height = null;
 
-  if (!utils.isEmpty(bidRequest.sizes)) {
-    // Ensure the size array is normalized
-    let conformingSize = utils.parseSizesInput(bidRequest.sizes);
-
-    if (!utils.isEmpty(conformingSize) && conformingSize[0] != null) {
-      // Currently only the first size is utilized
-      let splitSizes = conformingSize[0].split('x');
-
-      width = parseInt(splitSizes[0]);
-      height = parseInt(splitSizes[1]);
+  let requestedSizes = [];
+  let mediaTypes = bidRequest.mediaTypes;
+  if (mediaTypes && ((mediaTypes.banner && mediaTypes.banner.sizes) || (mediaTypes.video && mediaTypes.video.playerSize))) {
+    if (mediaTypes.banner) {
+      requestedSizes = mediaTypes.banner.sizes;
+    } else {
+      requestedSizes = [mediaTypes.video.playerSize];
     }
+  } else if (!utils.isEmpty(bidRequest.sizes)) {
+    requestedSizes = bidRequest.sizes
+  }
+
+  // Ensure the size array is normalized
+  let conformingSize = utils.parseSizesInput(requestedSizes);
+
+  if (!utils.isEmpty(conformingSize) && conformingSize[0] != null) {
+    // Currently only the first size is utilized
+    let splitSizes = conformingSize[0].split('x');
+
+    width = parseInt(splitSizes[0]);
+    height = parseInt(splitSizes[1]);
   }
 
   return {
@@ -109,22 +119,14 @@ let generateImpBody = (bidRequest) => {
   };
 }
 
-let generatePayload = (bidRequests) => {
+let generatePayload = (bidRequest) => {
   // Generate the expected OpenRTB payload
 
-  let rootBidRequest = bidRequests[0];
-
-  let index = 1;
-  bidRequests.forEach((bidRequest) => {
-    bidRequest.index = index;
-    index += 1;
-  })
-
   let payload = {
-    id: determineOptimalRequestId(rootBidRequest),
-    site: buildSiteComponent(rootBidRequest),
-    device: buildDeviceComponent(rootBidRequest),
-    imp: bidRequests.map(generateImpBody)
+    id: determineOptimalRequestId(bidRequest),
+    site: buildSiteComponent(bidRequest),
+    device: buildDeviceComponent(bidRequest),
+    imp: [generateImpBody(bidRequest)]
   };
 
   return JSON.stringify(payload);
@@ -165,37 +167,41 @@ let buildRequests = (validBidRequests, requestRoot) => {
   let adUnitCode = null;
   let rendererOverride = null;
 
+  let results = [];
   // Due to the nature of how URLs are generated, there must
   // be at least one bid request present for this to function
   // correctly
   if (!utils.isEmpty(validBidRequests)) {
-    let headBidRequest = validBidRequests[0];
+    results = validBidRequests.map(
+      bidRequest => {
+        let serverLocations = overridableProperties(bidRequest);
 
-    let serverLocations = overridableProperties(headBidRequest);
+        // requestUrl is the full endpoint w/ relevant adspot paramters
+        let placementId = determineOptimalPlacementId(bidRequest);
+        requestUrl = `${serverLocations.baseRequestPath}${placementId}/0/vo?z=${serverLocations.rotationZone}`;
 
-    // requestUrl is the full endpoint w/ relevant adspot paramters
-    let placementId = determineOptimalPlacementId(headBidRequest);
-    requestUrl = `${serverLocations.baseRequestPath}${placementId}/0/vo?z=${serverLocations.rotationZone}`;
+        // requestPayload is the POST body JSON for the OpenRtb request
+        requestPayload = generatePayload(bidRequest);
 
-    // requestPayload is the POST body JSON for the OpenRtb request
-    requestPayload = generatePayload(validBidRequests);
+        mediaTypes = bidRequest.mediaTypes;
+        adUnitCode = bidRequest.adUnitCode;
+        rendererOverride = bidRequest.rendererOverride;
 
-    mediaTypes = headBidRequest.mediaTypes;
-    adUnitCode = headBidRequest.adUnitCode;
-    rendererOverride = headBidRequest.rendererOverride;
+        return {
+          method: requestType,
+          type: requestType,
+          url: requestUrl,
+          data: requestPayload,
+          mediaTypes,
+          requestId: requestRoot.bidderRequestId,
+          adUnitCode,
+          rendererOverride
+        };
+      }
+    );
   }
-  const result = {
-    method: requestType,
-    type: requestType,
-    url: requestUrl,
-    data: requestPayload,
-    mediaTypes,
-    requestId: requestRoot.bidderRequestId,
-    adUnitCode,
-    rendererOverride
-  };
 
-  return result;
+  return results;
 };
 
 let outstreamRender = (bid) => {

--- a/modules/rockyouBidAdapter.md
+++ b/modules/rockyouBidAdapter.md
@@ -30,7 +30,7 @@ var adUnits = [
     bids: [{
           bidder: 'rockyou',
           params: {
-            placementId: '4322'
+            placementId: '4954'
           }
         }]
   },
@@ -49,7 +49,7 @@ var adUnits = [
     bids: [{
       bidder: 'rockyou',
       params: {
-        placementId: '4307'
+        placementId: '4957'
       }
     }]
   }

--- a/modules/rockyouBidAdapter.md
+++ b/modules/rockyouBidAdapter.md
@@ -24,9 +24,12 @@ var adUnits = [
   // Banner adUnit
   {
     code: 'banner-div',
-    sizes: [[720, 480]],
+    mediaTypes: {
+      banner: {
+        sizes: [[720, 480]]
+      }
+    },
 
-    // Replace this object to test a new Adapter!
     bids: [{
           bidder: 'rockyou',
           params: {
@@ -38,12 +41,10 @@ var adUnits = [
   // Video (outstream)
   {
     code: 'video-outstream',
-    sizes: [[720, 480]],
-
-    mediaType: 'video',
     mediaTypes: {
       video: {
-        context: 'outstream'
+        context: 'outstream',
+        playerSize: [720, 480]
       }
     },
     bids: [{


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Updated the RockYou Adapter to support:
* sizes coming from the mediaTypes object.
* an updated inventory zone
* multiple AdUnits

<!-- For new bidder adapters, please provide the following -->
- Test parameters have been updated (including in the README)
```
{
    code: 'banner-div',
    mediaTypes: {
      banner: {
        sizes: [[720, 480]]
      }
    },

    bids: [{
          bidder: 'rockyou',
          params: {
            placementId: '4954'
          }
        }]
  },

  // Video (outstream)
  {
    code: 'video-outstream',
    mediaTypes: {
      video: {
        context: 'outstream',
        playerSize: [720, 480]
      }
    },
    bids: [{
      bidder: 'rockyou',
      params: {
        placementId: '4957'
      }
    }]
  }
```

- contact email: prebid.adapter@rockyou.com 
- [X] official adapter submission

Note: no prebid doc changes are required for this PR