### PR TITLE
ADS-1687:

### DIFF
--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -64,6 +64,11 @@ let extractValidSize = (bidRequest) => {
     requestedSizes = bidRequest.sizes
   }
 
+  // Sort sizes by area, highest to lowest.
+  requestedSizes.sort(function(size1, size2){
+    return size2[0]*size2[1] - size1[0]*size1[1];
+  });
+
   // Ensure the size array is normalized
   let conformingSize = utils.parseSizesInput(requestedSizes);
 

--- a/modules/rockyouBidAdapter.js
+++ b/modules/rockyouBidAdapter.js
@@ -65,9 +65,7 @@ let extractValidSize = (bidRequest) => {
   }
 
   // Sort sizes by area, highest to lowest.
-  requestedSizes.sort(function(size1, size2){
-    return size2[0]*size2[1] - size1[0]*size1[1];
-  });
+  requestedSizes.sort((size1, size2) => (size2[0] * size2[1]) - (size1[0] * size1[1]));
 
   // Ensure the size array is normalized
   let conformingSize = utils.parseSizesInput(requestedSizes);

--- a/test/spec/modules/rockyouBidAdapter_spec.js
+++ b/test/spec/modules/rockyouBidAdapter_spec.js
@@ -38,7 +38,7 @@ describe('RockYouAdapter', () => {
       'auctionId': '18fd8b8b0bd757',
       'mediaTypes': {
         banner: {
-          'sizes': [[320, 50], [300, 250], [300, 600]]
+          'sizes': [[320, 50], [300, 600], [300, 250]]
         }
       }
     };
@@ -168,8 +168,8 @@ describe('RockYouAdapter', () => {
 
       let bannerData = firstImp.banner;
 
-      expect(bannerData.w).to.equal(320);
-      expect(bannerData.h).to.equal(50);
+      expect(bannerData.w).to.equal(300);
+      expect(bannerData.h).to.equal(600);
     });
 
     it('generates a banner request using a singular adSize instead of an array', () => {


### PR DESCRIPTION
    - Modified rockyouBidAdapter.js to sort sizes by area before selecting.
    - Updated the rockyouBidAdapter_spec.js

<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
